### PR TITLE
Fix comments

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,7 +8,7 @@ export class DocumentAPI {
 }
 
 export class CommentAPI {
-    static GithubIssueUrl: string = "https://api.github.yuuza.net/repos/sanyuankexie/hellokexie/issues/6/comments"
+    static GithubIssueUrl: string = "https://api.github.com/repos/sanyuankexie/hellokexie/issues/6/comments"
 }
 
 export class MusicAPI {


### PR DESCRIPTION
上古学长的链接失效了，换回 Github 的官方链接。