### PR TITLE
fix(release): 锚定上一个 release,修正版本倒退

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
+      "last-release-sha": "d5a4465edf1340b390cf5b139c3d0d96c04bf3bc",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## 问题

上个 PR 把 tag 改为 v 开头(`include-component-in-tag: false`)后,release-please 生成的 release PR #37 是错的:

| 项 | 值 |
|---|---|
| 版本号 | `1.5.2` → **`1.5.1`(倒退降版本)** |
| CHANGELOG | 灌入自 v1.3.2 起的**全部历史 commit** |
| compare 链接 | `compare/v1.5.2...v1.5.1`(方向颠倒) |

**根因**:去掉 component 前缀后它改查 `v*` 格式的 tag,而仓库内该格式只剩远古的 `v1.3.2`(1.4.0 起打的都是 `kexie-web-v*`),于是把 v1.3.2 当成了上一个 release。

## 修法

用 `last-release-sha` 显式锚定 `kexie-web-v1.5.2` 指向的 commit `d5a4465`,让它正确地 1.5.2 → 1.5.3。

这个问题只存在于新旧格式交界这一次 —— **发出 v1.5.3 之后 `last-release-sha` 就可以删掉**,届时它能正常找到 v* 格式的上一个 tag。

**没有采用补打 `v1.5.2` 锚点 tag 的方案**:那个 tag 指向的旧 commit 上 `deploy-docker.yml` 仍是 `v*` 触发,推送它会用 4/30 的旧代码构建并覆盖 registry 里的 `:latest`。

## 合并后

需先关掉错误的 PR #37 并删除其分支,让 release-please 重新生成。我会把新 release PR 的 diff 贴出来确认版本号为 1.5.3、changelog 只含本次改动,再合并发版。