### PR TITLE
fix(release): last-release-sha 移至顶层

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "d5a4465edf1340b390cf5b139c3d0d96c04bf3bc",
   "packages": {
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
-      "last-release-sha": "d5a4465edf1340b390cf5b139c3d0d96c04bf3bc",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
上一个 PR 把 `last-release-sha` 放在了 `packages['.']` 下,而 release-please 的 schema 中它是**顶层属性**,放在 package 级别会被静默忽略。

已核对官方 schema:

| 位置 | 是否支持 |
|---|---|
| 顶层 properties | ✅ True |
| package 级别 | ❌ False |

因此上个修复并未生效,release PR #53 仍是 1.5.2 → 1.5.1 倒退。本 PR 将其移到顶层。

合并后 release-please 应生成 1.5.2 → **1.5.3**、changelog 仅含本次改动的 release PR。我会贴出 diff 确认后再合并发版。