### PR TITLE
fix(assets): GuethubApp 截图改用 cos.ts 常量并转为 WebP

### DIFF
--- a/src/pages/Welcome/GuethubApp.tsx
+++ b/src/pages/Welcome/GuethubApp.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from "react";
 import Slider from "react-slick";
 import Section from "../../component/Section";
 import {useScrollHandler} from "../../hooks";
+import {GuethubAppAssets} from "../../static/cos";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
@@ -20,12 +21,7 @@ function GuethubApp() {
         return () => window.removeEventListener("resize", handleResize);
     }, []);
 
-    const mobileImages = [
-        "https://api.kexie.space/data/resource/hello/docs/introduction/appdev-assets/guethub-app-mobile-1.png",
-        "https://api.kexie.space/data/resource/hello/docs/introduction/appdev-assets/guethub-app-mobile-2.png",
-        "https://api.kexie.space/data/resource/hello/docs/introduction/appdev-assets/guethub-app-mobile-3.png",
-    ];
-
+    const mobileImages = GuethubAppAssets.Screenshots;
 
     const settings = {
         dots: true,

--- a/src/static/cos.ts
+++ b/src/static/cos.ts
@@ -46,3 +46,11 @@ export const Video = {
 export const Docs = {
   PrefixUrl: `${BaseUrl}/docs/introduction`,
 };
+
+export const GuethubAppAssets = {
+  Screenshots: [
+    `${Docs.PrefixUrl}/appdev-assets/guethub-app-mobile-1.webp`,
+    `${Docs.PrefixUrl}/appdev-assets/guethub-app-mobile-2.webp`,
+    `${Docs.PrefixUrl}/appdev-assets/guethub-app-mobile-3.webp`,
+  ],
+} as const;


### PR DESCRIPTION
## 问题

这三张图以**完整 URL 硬编码**在 `GuethubApp.tsx` 内,绕开了 `cos.ts` 的 `BaseUrl`,因此上次批量替换(只覆盖 `${BaseUrl}/images/` 形式)遗漏了它们,线上仍在请求 `.png`。

## 改动

改为在 `cos.ts` 中以 `GuethubAppAssets` 集中声明,复用 `Docs.PrefixUrl` 拼接路径,与仓库内其他资源地址的管理方式一致。

WebP 早已上传至对象存储,本次仅修正引用:

| 文件 | 原 | WebP | 节省 |
|---|---|---|---|
| mobile-1 | 399,895 | 64,320 | -84% |
| mobile-2 | 581,237 | 98,976 | -83% |
| mobile-3 | 1,425,009 | 119,450 | -92% |

合计约 2.4MB → 283KB。

已全库复查,`src` 与 `index.html` 中不再有指向对象存储的 `.png/.jpg/.gif` 引用。